### PR TITLE
新增：Go 打包前端代码的示例

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ pythonenv*
 
 # zouying
 **/prometheus/prometheus.yml
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 另外， [Go 常见的错误汇总](./CommonError.md) 汇总常见的错误问题。
 
+
+# List Table
+
+- [Go 打包前端代码的示例](./go_embed_front_source/) - 使用 Go embed 特性直接在二进制中打包发布前端服务的示例。
+
+
 # Reading List
 
 -   [Go 语言之父谈 Go 编程语言与环境](https://mp.weixin.qq.com/s?__biz=MzIyNzM0MDk0Mg==&mid=2247490227&idx=1&sn=620d9ab5f06c64852a141e43abf44fef&cur_album_id=1509674724665163776#wechat_redirect) - Rob Pike 介绍 Go 的特性。这篇文章可以看到 Go 语言与其他语言的区别所在。

--- a/go_embed_front_source/README.md
+++ b/go_embed_front_source/README.md
@@ -1,0 +1,28 @@
+# README
+
+Go 代码直接打包前端代码，使用 embed 特性。（需要 Go 1.16 以上能力支持）
+
+
+## 1. 运行
+
+### 1.1 前端代码
+
+代码统一在 [./dist](./dist/) 目录。
+
+### 1.2 后端代码
+
+直接运行，会打包前端源码。
+
+```bash
+go run .
+```
+
+### 1.3 测试
+
+浏览器打开地址： `http://dev.zy.local:9090/`，更换成自己的地址即可。
+
+
+
+## 2. Refs:
+
+https://v0x.nl/articles/portable-apps-go-nextjs

--- a/go_embed_front_source/dist/foo/index.html
+++ b/go_embed_front_source/dist/foo/index.html
@@ -1,0 +1,15 @@
+<html>
+
+<head>
+    Hello Go
+</head>
+
+<body>
+    <h1>Foo Page</h1>
+
+    <p>
+        Check out <a href="/">Home Page</a>
+    </p>
+</body>
+
+</html>

--- a/go_embed_front_source/dist/index.html
+++ b/go_embed_front_source/dist/index.html
@@ -1,0 +1,15 @@
+<html>
+
+<head>
+    Hello Go
+</head>
+
+<body>
+    <h1>Home Page</h1>
+
+    <p>
+        Check out <a href="/foo">Foo Page</a>
+    </p>
+</body>
+
+</html>

--- a/go_embed_front_source/frontend/package.json
+++ b/go_embed_front_source/frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "zouying",
+  "license": "ISC"
+}

--- a/go_embed_front_source/go.mod
+++ b/go_embed_front_source/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.18

--- a/go_embed_front_source/main.go
+++ b/go_embed_front_source/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"embed"
+	"io/fs"
+	"log"
+	"net/http"
+)
+
+//go:embed all:dist
+var distFS embed.FS
+
+func main() {
+
+	distFS, err := fs.Sub(distFS, "dist")
+	panicError(err)
+
+	http.Handle("/", http.FileServer(http.FS(distFS)))
+
+	log.Printf("starting HTTP server at :9090")
+	log.Fatal(http.ListenAndServe(":9090", nil))
+}
+
+func panicError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
[Go 打包前端代码的示例](./go_embed_front_source/)
使用 Go embed 特性直接在二进制中打包发布前端服务的示例。